### PR TITLE
Cursor suggestion fixes

### DIFF
--- a/packages/SBBash/SBBashCommandBlock.class.st
+++ b/packages/SBBash/SBBashCommandBlock.class.st
@@ -17,6 +17,12 @@ SBBashCommandBlock >> addInput: aString [
 ]
 
 { #category : #'as yet unclassified' }
+SBBashCommandBlock >> floating [
+
+	^ true
+]
+
+{ #category : #'as yet unclassified' }
 SBBashCommandBlock >> focus [
 
 	input startInputAtEnd

--- a/packages/SBBash/SBBashEditor.class.st
+++ b/packages/SBBash/SBBashEditor.class.st
@@ -32,11 +32,11 @@ SBBashEditor >> initialize [
 
 	super initialize.
 	
-	self openMorphInView: (SBBashTerminal new
+	self openMorph: (SBBashTerminal new
 		hResizing: #spaceFill;
 		vResizing: #spaceFill).
 	
-	self submorphs second addMorphBack: (SBBlock new
+	self submorphs second addMorphBack: (SBColumn new
 		addMorphBack: (synopsisBlock := SBBashFormattedTextBubble multiLine
 			placeholderText: 'No synopsis found';
 			focusable: false;
@@ -47,9 +47,13 @@ SBBashEditor >> initialize [
 		addMorphBack: (descriptionBlock := SBBashFormattedTextBubble multiLine
 			placeholderText: 'No description found';
 			focusable: false;
-			maxWidth: 200);
-		changeTableLayout;
-		listDirection: #topToBottom)
+			maxWidth: 200))
+]
+
+{ #category : #'as yet unclassified' }
+SBBashEditor >> insertCommandRequest: aMorph near: aBlock before: aBoolean [
+
+	^ nil
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/SBBash/SBBashFormattedTextBubble.class.st
+++ b/packages/SBBash/SBBashFormattedTextBubble.class.st
@@ -15,6 +15,25 @@ SBBashFormattedTextBubble >> click: anEvent [
 ]
 
 { #category : #'as yet unclassified' }
+SBBashFormattedTextBubble >> contents: aString [
+
+	self assert: aString notNil.
+	super contents: aString
+]
+
+{ #category : #'as yet unclassified' }
+SBBashFormattedTextBubble >> currentTextMorph [
+
+	^ focusable ifTrue: [super currentTextMorph] ifFalse: [nil]
+]
+
+{ #category : #'as yet unclassified' }
+SBBashFormattedTextBubble >> cursorPositionsDo: aBlock shallow: aBoolean [
+
+	focusable ifTrue: [super cursorPositionsDo: aBlock shallow: aBoolean]
+]
+
+{ #category : #'as yet unclassified' }
 SBBashFormattedTextBubble >> focusable [
 
 	^ focusable

--- a/packages/SBBash/SBBashInput.class.st
+++ b/packages/SBBash/SBBashInput.class.st
@@ -56,8 +56,11 @@ SBBashInput class >> loadInsertSubcommandsFrom: anInfoObject into: collection [
 	"TODO: machen, dass das richtig geparst wird --> command davor, aber nicht alle Blöcke nehmen"
 	subcommands do: [:subcmd |
 		collection add: (SBBashInsertSuggestionItem new
-			morph: (self parseToplevel: anInfoObject mainCommand, ' ', subcmd) childSandblocks first childSandblocks second
-			previewOnly: true)]
+			morphs: {
+				(self blockFor: #word)
+					contents: subcmd;
+					yourself}
+			editor: anInfoObject sandblockEditor)]
 ]
 
 { #category : #'as yet unclassified' }
@@ -67,8 +70,8 @@ SBBashInput class >> loadInsertSuggestionsFrom: anInfoObject into: collection [
 		flagInfo := SBBashFlagInformation new
 			description: (option at: #description);
 			flags: (option at: #flags);
-			arguments: (option at: #arguments);
-			optionals: (option at: #optionals).
+			arguments: ((option at: #arguments) ifNil: [{}]);
+			optionals: ((option at: #optionals) ifNil: [{}]).
 		
 		morphs := OrderedCollection new.
 		flagInfo arguments
@@ -127,8 +130,7 @@ SBBashInput class >> loadSubcommandsFrom: anInfoObject into: collection [
 	subcommands do: [:subcmd |
 		(subcmd findString: anInfoObject searchString) > 0 ifTrue: [
 			collection add: (SBBashTSBlockSuggestion new
-				blocks: {
-					(self parseToplevel: anInfoObject mainCommand, (' ', subcmd)) childSandblocks first childSandblocks second}
+				blocks: {(self blockFor: #word) contents: subcmd}
 				in: anInfoObject sandblockEditor)]]
 ]
 
@@ -139,8 +141,8 @@ SBBashInput class >> loadSuggestionsFrom: anInfoObject into: collection [
 		flagInfo := SBBashFlagInformation new
 			description: (option at: #description);
 			flags: (option at: #flags);
-			arguments: (option at: #arguments);
-			optionals: (option at: #optionals).
+			arguments: ((option at: #arguments) ifNil: [{}]);
+			optionals: ((option at: #optionals) ifNil: [{}]).
 		
 		morphs := OrderedCollection new.
 		flagInfo arguments

--- a/packages/SBBash/SBBashInsertSuggestionItem.class.st
+++ b/packages/SBBash/SBBashInsertSuggestionItem.class.st
@@ -61,5 +61,5 @@ SBBashInsertSuggestionItem >> selector: aString [
 { #category : #'as yet unclassified' }
 SBBashInsertSuggestionItem >> useSuggestionOn: aCommand in: anEditor [
 
-	anEditor do: (aCommand morphs: morphs)
+	anEditor do: (aCommand morphs: (SBTSInputParser new adaptSlotsFor: morphs to: aCommand element))
 ]

--- a/packages/SBBash/SBBashTSBlockSuggestion.class.st
+++ b/packages/SBBash/SBBashTSBlockSuggestion.class.st
@@ -11,16 +11,12 @@ Class {
 { #category : #'as yet unclassified' }
 SBBashTSBlockSuggestion >> blocks: aCollection in: anEditor popup: aPopup [
 
-	disambiguatePopup := aPopup.
-	self
-		preview: (anEditor newSelectionContainer
-			addAllMorphs: aCollection;
-			width: 400;
-			imageForm;
-			changeTableLayout;
-			listDirection: #leftToRight)
-		previewOnly: false.
-	^ blocks := aCollection
+	super
+		blocks: (SBReplaceMultipleCommand new
+			target: anEditor selection
+			replacers: (aCollection collect: [:m | m isTSBlock ifTrue: [m adaptSlotFor: anEditor selection slot] ifFalse: [m]]))
+		in: anEditor
+		popup: aPopup
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/SBBash/SBBashTerminal.class.st
+++ b/packages/SBBash/SBBashTerminal.class.st
@@ -84,7 +84,7 @@ SBBashTerminal >> description [
 { #category : #'as yet unclassified' }
 SBBashTerminal >> description: aString [
 
-	self sandblockEditor descriptionBlock contents: aString.
+	self sandblockEditor descriptionBlock contents: (aString ifNil: ['']).
 	description := aString
 ]
 
@@ -142,6 +142,12 @@ SBBashTerminal >> initialize [
 	commands := OrderedCollection new.
 	monitorSemaphor := Semaphore new.
 	self launchBash
+]
+
+{ #category : #'as yet unclassified' }
+SBBashTerminal >> insertCommandRequest: aMorph near: aBlock before: aBoolean [
+
+	^ nil
 ]
 
 { #category : #'as yet unclassified' }
@@ -286,7 +292,7 @@ SBBashTerminal >> state: aSymbol [
 { #category : #'as yet unclassified' }
 SBBashTerminal >> synopsis: aString [
 
-	self sandblockEditor synopsisBlock contents: aString.
+	self sandblockEditor synopsisBlock contents: (aString ifNil: ['']).
 	synopsis := aString
 ]
 


### PR DESCRIPTION
* add nil-checks for incomplete man-page parses (these may have only been necessary because some tool worked incorrectly?)
* update to new suggestions API
* prevent cursor from leaving a command block (e.g., holding down backspace now works); blocks up-arrow too at the moment but that could be changed

Depends on the most recent version of both Sandblocks and sb-tree-sitter.